### PR TITLE
use the cleaner noop + deps syntax supported by moon 1.6

### DIFF
--- a/apps/server/moon.yml
+++ b/apps/server/moon.yml
@@ -65,13 +65,15 @@ tasks:
     options:
       outputStyle: 'stream'
   dev:
-    command: 'moon run server:dev-build server:dev-start'
+    # This was required prior to moon 1.6
+    # command: 'moon run server:dev-build server:dev-start'
+    local: true
+    command: 'noop'
+    deps:
+      - '~:dev-build'
+      - '~:dev-start'
     options:
       outputStyle: 'stream'
-    # command: 'noop'
-    # deps:
-    #   - '~:dev-build'
-    #   - '~:dev-start'
   # Tasks under development
   build-docker:
     command: 'docker image rm --force restaurant-backend; docker build . --tag restaurant-backend'


### PR DESCRIPTION
From this point on everyone in the team should use `moon 1.6` and newer

@denigogov @surmavagit 